### PR TITLE
feat: #12 - Añade un dialogo de confirmación cuando se vaya a borrar una tarea

### DIFF
--- a/app_docs/conditional_docs.md
+++ b/app_docs/conditional_docs.md
@@ -1,0 +1,13 @@
+# Conditional Documentation Index
+
+Este archivo indexa la documentación de features implementados y especifica las condiciones bajo las cuales cada documento es relevante. Usa esta guía para determinar qué documentación leer según el contexto de tu trabajo.
+
+## Documentos
+
+- app_docs/feature-b16df508-delete-task-confirmation.md
+  - Condiciones:
+    - Cuando se trabaje con eliminación de tareas o acciones destructivas
+    - Cuando se implemente confirmación de usuario para operaciones críticas
+    - Cuando se necesite crear diálogos modales reutilizables
+    - Cuando se resuelvan problemas relacionados con eliminaciones accidentales o falta de confirmación en la UI
+    - Cuando se trabaje con los componentes `TaskItem` o `ConfirmDialog`

--- a/app_docs/feature-b16df508-delete-task-confirmation.md
+++ b/app_docs/feature-b16df508-delete-task-confirmation.md
@@ -1,0 +1,95 @@
+# Diálogo de Confirmación al Borrar Tarea
+
+**ADW ID:** b16df508
+**Fecha:** 2026-03-03
+**Especificacion:** .issues/12/plan.md
+
+## Overview
+
+Se implementó un diálogo modal de confirmación que se muestra antes de eliminar una tarea en la aplicación Todo List. Esta funcionalidad previene eliminaciones accidentales al solicitar confirmación explícita del usuario antes de ejecutar la acción destructiva.
+
+## Que se Construyo
+
+- Componente `ConfirmDialog` reutilizable con overlay modal
+- Integración del diálogo de confirmación en el flujo de eliminación de tareas
+- Estilos CSS consistentes con el diseño existente de la aplicación
+- Suite completa de tests unitarios para el nuevo componente
+- Tests actualizados de `TaskItem` para cubrir el flujo de confirmación
+
+## Implementacion Tecnica
+
+### Ficheros Modificados
+
+- `frontend/src/components/ConfirmDialog.jsx`: Nuevo componente modal reutilizable que muestra un mensaje de confirmación con botones Cancelar y Eliminar
+- `frontend/src/__tests__/ConfirmDialog.test.jsx`: Suite de tests unitarios para validar el comportamiento del diálogo de confirmación
+- `frontend/src/components/TaskItem.jsx`: Integrado estado local `showConfirm` y renderizado del `ConfirmDialog` interceptando el click del botón eliminar
+- `frontend/src/__tests__/TaskItem.test.jsx`: Tests actualizados para verificar el flujo completo de confirmación antes de eliminar
+- `frontend/src/index.css`: Añadidos estilos CSS para overlay, diálogo, botones secundarios y de peligro
+- `frontend/package.json`: Añadida dependencia de desarrollo `@testing-library/user-event` para simular interacciones de usuario en tests
+
+### Cambios Clave
+
+1. **Componente ConfirmDialog**: Componente React controlado por prop `isOpen` que renderiza un overlay modal con mensaje personalizable y callbacks `onConfirm` y `onCancel`. Incluye event propagation stop para evitar cerrar al hacer click dentro del diálogo.
+
+2. **Gestión de estado en TaskItem**: Se añadió `useState(false)` para controlar la visibilidad del diálogo. El botón "Eliminar" ahora abre el diálogo en lugar de ejecutar `onDelete` directamente.
+
+3. **Sistema de estilos modular**: Nuevas clases CSS `.confirm-overlay`, `.confirm-dialog`, `.confirm-message`, `.confirm-actions`, `.btn-secondary` y `.btn-danger` siguiendo los patrones de diseño existentes (border-radius 8px, transiciones, colores consistentes).
+
+4. **Cobertura de tests completa**: Tests unitarios para `ConfirmDialog` verificando renderizado condicional, callbacks y botones. Tests de integración en `TaskItem` verificando que el diálogo se muestra antes de eliminar y que cancelar no ejecuta la eliminación.
+
+5. **Patrón de confirmación reutilizable**: El diseño del componente permite reutilizarlo en futuras funcionalidades que requieran confirmación del usuario sin modificar el código existente.
+
+## Como Usar
+
+1. **Para usuarios finales**: Al hacer click en el botón "Eliminar" de cualquier tarea, aparecerá un diálogo modal preguntando "¿Estás seguro de que quieres eliminar la tarea '[título de la tarea]'?"
+
+2. **Confirmar eliminación**: Hacer click en el botón rojo "Eliminar" del diálogo para proceder con la eliminación
+
+3. **Cancelar**: Hacer click en el botón gris "Cancelar" o fuera del diálogo para cerrar sin eliminar la tarea
+
+4. **Para desarrolladores**: Importar y usar `ConfirmDialog` en cualquier componente:
+```jsx
+import { useState } from 'react'
+import ConfirmDialog from './ConfirmDialog'
+
+const [showConfirm, setShowConfirm] = useState(false)
+
+<ConfirmDialog
+  isOpen={showConfirm}
+  message="Tu mensaje de confirmación"
+  onConfirm={() => {
+    // Acción a ejecutar al confirmar
+    setShowConfirm(false)
+  }}
+  onCancel={() => setShowConfirm(false)}
+/>
+```
+
+## Configuracion
+
+No se requiere configuración adicional. El componente funciona out-of-the-box con los estilos globales definidos en `index.css`.
+
+## Testing
+
+**Ejecutar tests del frontend:**
+```bash
+cd frontend && npm test
+```
+
+**Tests incluidos:**
+- ConfirmDialog no renderiza cuando `isOpen` es false
+- ConfirmDialog muestra el mensaje cuando está abierto
+- Botones "Cancelar" y "Eliminar" están presentes
+- Callback `onCancel` se ejecuta al hacer click en "Cancelar"
+- Callback `onConfirm` se ejecuta al hacer click en "Eliminar"
+- TaskItem muestra el diálogo al hacer click en eliminar
+- TaskItem ejecuta `onDelete` solo después de confirmar
+- TaskItem no elimina la tarea al cancelar
+
+## Notas
+
+- El componente `ConfirmDialog` es completamente reutilizable y puede adaptarse a cualquier caso de uso que requiera confirmación del usuario
+- No se introdujeron nuevas dependencias de producción; solo se añadió `@testing-library/user-event` como dependencia de desarrollo para mejorar los tests de interacción
+- El estado del diálogo se gestiona localmente en cada instancia de uso (como `TaskItem`), manteniendo la simplicidad y evitando overhead de contexto global
+- El diseño del overlay permite cerrar el diálogo haciendo click fuera del contenido, mejorando la UX
+- Los estilos están alineados con el sistema de diseño existente de la aplicación (colores, border-radius, sombras)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.3.0",
         "jsdom": "^25.0.0",
         "vite": "^6.0.0",
@@ -1434,6 +1435,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.3.0",
     "jsdom": "^25.0.0",
     "vite": "^6.0.0",

--- a/frontend/src/__tests__/ConfirmDialog.test.jsx
+++ b/frontend/src/__tests__/ConfirmDialog.test.jsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ConfirmDialog from '../components/ConfirmDialog'
+
+describe('ConfirmDialog', () => {
+  it('does not render when isOpen is false', () => {
+    const { container } = render(
+      <ConfirmDialog
+        isOpen={false}
+        message="Test message"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the message when open', () => {
+    const testMessage = 'Are you sure you want to delete this item?'
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        message={testMessage}
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByText(testMessage)).toBeInTheDocument()
+  })
+
+  it('shows Cancelar and Eliminar buttons', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        message="Test message"
+        onConfirm={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    expect(screen.getByText('Cancelar')).toBeInTheDocument()
+    expect(screen.getByText('Eliminar')).toBeInTheDocument()
+  })
+
+  it('calls onCancel when Cancelar button is clicked', async () => {
+    const user = userEvent.setup()
+    const onCancel = vi.fn()
+
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        message="Test message"
+        onConfirm={vi.fn()}
+        onCancel={onCancel}
+      />
+    )
+
+    await user.click(screen.getByText('Cancelar'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onConfirm when Eliminar button is clicked', async () => {
+    const user = userEvent.setup()
+    const onConfirm = vi.fn()
+
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        message="Test message"
+        onConfirm={onConfirm}
+        onCancel={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByText('Eliminar'))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/__tests__/TaskItem.test.jsx
+++ b/frontend/src/__tests__/TaskItem.test.jsx
@@ -1,4 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import TaskItem from '../components/TaskItem'
 
 vi.mock('@dnd-kit/sortable', () => ({
@@ -47,12 +48,46 @@ test('calls onToggle when checkbox is clicked', () => {
   expect(mockToggle).toHaveBeenCalledWith(1)
 })
 
-test('calls onDelete when delete button is clicked', () => {
+test('shows confirmation dialog when delete button is clicked', () => {
   const mockDelete = vi.fn()
   render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={mockDelete} />)
 
   fireEvent.click(screen.getByRole('button', { name: /eliminar/i }))
-  expect(mockDelete).toHaveBeenCalledWith(1)
+
+  expect(screen.getByText(/¿Estás seguro de que quieres eliminar la tarea/i)).toBeInTheDocument()
+  expect(mockDelete).not.toHaveBeenCalled()
+})
+
+test('calls onDelete only after confirmation', async () => {
+  const user = userEvent.setup()
+  const mockDelete = vi.fn()
+  render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={mockDelete} />)
+
+  // Click delete button
+  await user.click(screen.getByRole('button', { name: /eliminar/i }))
+
+  // Confirm deletion
+  const confirmButton = screen.getAllByRole('button', { name: /eliminar/i })[1]
+  await user.click(confirmButton)
+
+  await waitFor(() => {
+    expect(mockDelete).toHaveBeenCalledWith(1)
+  })
+})
+
+test('closes dialog and does not delete when cancelled', async () => {
+  const user = userEvent.setup()
+  const mockDelete = vi.fn()
+  render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={mockDelete} />)
+
+  // Click delete button
+  await user.click(screen.getByRole('button', { name: /eliminar/i }))
+
+  // Cancel deletion
+  await user.click(screen.getByRole('button', { name: /cancelar/i }))
+
+  expect(mockDelete).not.toHaveBeenCalled()
+  expect(screen.queryByText(/¿Estás seguro de que quieres eliminar la tarea/i)).not.toBeInTheDocument()
 })
 
 test('renders drag handle', () => {

--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function ConfirmDialog({ isOpen, message, onConfirm, onCancel }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="confirm-overlay" onClick={onCancel}>
+      <div className="confirm-dialog" onClick={(e) => e.stopPropagation()}>
+        <p className="confirm-message">{message}</p>
+        <div className="confirm-actions">
+          <button className="btn btn-secondary" onClick={onCancel}>
+            Cancelar
+          </button>
+          <button className="btn btn-danger" onClick={onConfirm}>
+            Eliminar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ConfirmDialog;

--- a/frontend/src/components/TaskItem.jsx
+++ b/frontend/src/components/TaskItem.jsx
@@ -1,7 +1,10 @@
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { useState } from 'react'
+import ConfirmDialog from './ConfirmDialog'
 
 function TaskItem({ task, onToggle, onDelete }) {
+  const [showConfirm, setShowConfirm] = useState(false)
   const {
     attributes,
     listeners,
@@ -34,11 +37,20 @@ function TaskItem({ task, onToggle, onDelete }) {
         {task.title}
       </span>
       <button
-        onClick={() => onDelete(task.id)}
+        onClick={() => setShowConfirm(true)}
         className="btn btn-delete"
       >
         Eliminar
       </button>
+      <ConfirmDialog
+        isOpen={showConfirm}
+        message={`¿Estás seguro de que quieres eliminar la tarea "${task.title}"?`}
+        onConfirm={() => {
+          onDelete(task.id)
+          setShowConfirm(false)
+        }}
+        onCancel={() => setShowConfirm(false)}
+      />
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -148,3 +148,57 @@ p {
   text-decoration: line-through;
   color: #999;
 }
+
+/* Confirm Dialog */
+.confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.confirm-dialog {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-width: 400px;
+  width: 90%;
+}
+
+.confirm-message {
+  margin-bottom: 1.5rem;
+  color: #333;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.confirm-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.btn-secondary {
+  background-color: #95a5a6;
+  color: white;
+}
+
+.btn-secondary:hover {
+  background-color: #7f8c8d;
+}
+
+.btn-danger {
+  background-color: #e74c3c;
+  color: white;
+}
+
+.btn-danger:hover {
+  background-color: #c0392b;
+}


### PR DESCRIPTION
## Summary
Añade un diálogo modal de confirmación antes de eliminar una tarea para evitar borrados accidentales. El componente `ConfirmDialog` es reutilizable y se integra en `TaskItem` mostrando el título de la tarea antes de confirmar la eliminación.

Closes #12

## Implementation Plan
See implementation plan in issue #12 comments

## Changes
- Nuevo componente `ConfirmDialog` reutilizable con overlay modal
- Integración del diálogo de confirmación en `TaskItem`
- Estilos CSS para el modal siguiendo patrones existentes
- Tests unitarios completos para `ConfirmDialog`
- Tests de integración actualizados en `TaskItem` para el flujo de confirmación
- Documentación de la funcionalidad en `app_docs/feature-b16df508-delete-task-confirmation.md`

## ADW
ADW ID: b16df508
