### PR TITLE
feature: #16 - Añade un dialogo de confirmación cuando se vaya a borrar una tarea

### DIFF
--- a/app_docs/conditional_docs.md
+++ b/app_docs/conditional_docs.md
@@ -1,0 +1,13 @@
+# Documentación Condicional
+
+Este fichero mapea la documentación de features a las condiciones bajo las cuales debe ser consultada. Ayuda a futuros desarrolladores a saber cuándo leer cada documentación específica.
+
+## Índice de Documentación
+
+- app_docs/feature-16-delete-confirmation-dialog.md
+  - Condiciones:
+    - Cuando se trabaje con eliminación de tareas o items
+    - Cuando se implemente confirmación de acciones destructivas
+    - Cuando se creen componentes modales o diálogos reutilizables
+    - Cuando se resuelvan problemas de eliminaciones accidentales o UX de confirmación
+    - Cuando se necesite entender el patrón de diálogos modales en la aplicación

--- a/app_docs/feature-16-delete-confirmation-dialog.md
+++ b/app_docs/feature-16-delete-confirmation-dialog.md
@@ -1,0 +1,70 @@
+# Diálogo de Confirmación al Borrar Tarea
+
+**ADW ID:** 16
+**Fecha:** 2026-03-03
+**Especificación:** .issues/16/plan.md
+
+## Overview
+
+Se implementó un diálogo de confirmación modal que aparece antes de eliminar una tarea. Esto previene eliminaciones accidentales y mejora la experiencia de usuario al ofrecer la opción de cancelar la acción antes de que sea irreversible.
+
+## Qué se Construyó
+
+- Componente reutilizable `ConfirmDialog` para mostrar diálogos de confirmación modales
+- Integración del diálogo en el componente `TaskItem` para confirmar eliminaciones
+- Estilos CSS para el overlay y el diálogo modal
+- Tests unitarios completos para el nuevo componente y el flujo actualizado
+
+## Implementación Técnica
+
+### Ficheros Modificados
+
+- `frontend/src/components/ConfirmDialog.jsx`: Nuevo componente modal reutilizable con soporte para título, mensaje y callbacks de confirmación/cancelación
+- `frontend/src/components/TaskItem.jsx`: Añadida gestión de estado local para controlar visibilidad del diálogo y flujo de confirmación antes de eliminar
+- `frontend/src/index.css`: Añadidos estilos CSS para `.confirm-overlay`, `.confirm-dialog`, `.confirm-title`, `.confirm-message`, `.confirm-actions` y `.btn-cancel`
+- `frontend/src/__tests__/ConfirmDialog.test.jsx`: Suite completa de tests para el componente `ConfirmDialog`
+- `frontend/src/__tests__/TaskItem.test.jsx`: Actualizados tests existentes y añadidos nuevos tests para verificar el flujo de confirmación
+
+### Cambios Clave
+
+1. **Componente ConfirmDialog**: Componente modal reutilizable que renderiza condicionalmente basado en prop `isOpen`. Incluye overlay semitransparente, caja de diálogo centrada, título, mensaje y botones de acción. Soporta cierre al hacer clic en el overlay.
+
+2. **Integración en TaskItem**: Se añadió estado local `showConfirm` usando `useState` para controlar la visibilidad del diálogo. El botón "Eliminar" ahora abre el diálogo en lugar de llamar directamente a `onDelete`. La eliminación solo ocurre cuando el usuario confirma en el diálogo.
+
+3. **Estilos CSS**: Modal con overlay `position: fixed` y `z-index: 1000`, diseño responsive con `max-width: 400px`, estilos flexbox para los botones de acción, y estilos hover para mejor feedback visual.
+
+4. **Tests Completos**: Tests para renderizado condicional del diálogo, verificación de callbacks, tests para ambos botones (Cancelar/Eliminar), y tests para cierre al hacer clic en el overlay. Tests actualizados en TaskItem verifican el flujo completo: abrir diálogo → confirmar → eliminar.
+
+## Cómo Usar
+
+1. Al hacer clic en el botón "Eliminar" de una tarea, aparece un diálogo de confirmación modal
+2. El diálogo muestra el título de la tarea que se va a eliminar: "¿Estás seguro de que quieres eliminar "[título de la tarea]"?"
+3. El usuario tiene tres opciones:
+   - Hacer clic en "Cancelar" para cerrar el diálogo sin eliminar la tarea
+   - Hacer clic en "Eliminar" para confirmar y eliminar la tarea
+   - Hacer clic fuera del diálogo (en el overlay oscuro) para cerrar sin eliminar
+
+## Configuración
+
+No requiere configuración adicional. El componente funciona out-of-the-box sin dependencias externas.
+
+## Testing
+
+### Ejecutar Tests
+
+```bash
+cd frontend && npm test
+```
+
+### Cobertura de Tests
+
+- **ConfirmDialog**: 5 tests que verifican renderizado condicional, renderizado de título y mensaje, callbacks de botones, y cierre al hacer clic en overlay
+- **TaskItem**: 3 tests que verifican el flujo completo de confirmación, cancelación sin eliminar, y visualización del título de la tarea en el diálogo
+
+## Notas
+
+- El componente `ConfirmDialog` está diseñado como reutilizable y puede usarse en otras partes de la aplicación para confirmaciones futuras
+- No se añadieron dependencias externas; el modal está implementado con CSS puro y React hooks nativos
+- El componente usa `position: fixed` con `z-index: 1000` para garantizar que siempre aparezca sobre otros elementos
+- Se podría considerar en el futuro añadir soporte para la tecla Escape para cerrar el diálogo, pero no es parte de esta implementación inicial
+- La funcionalidad de arrastrar y soltar (drag-and-drop) no se ve afectada por esta implementación

--- a/frontend/src/__tests__/ConfirmDialog.test.jsx
+++ b/frontend/src/__tests__/ConfirmDialog.test.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ConfirmDialog from '../components/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  const mockOnConfirm = vi.fn();
+  const mockOnCancel = vi.fn();
+
+  beforeEach(() => {
+    mockOnConfirm.mockClear();
+    mockOnCancel.mockClear();
+  });
+
+  it('does not render when isOpen is false', () => {
+    const { container } = render(
+      <ConfirmDialog
+        isOpen={false}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders title and message when isOpen is true', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+    expect(screen.getByText('Test Message')).toBeInTheDocument();
+    expect(screen.getByText('Cancelar')).toBeInTheDocument();
+    expect(screen.getByText('Eliminar')).toBeInTheDocument();
+  });
+
+  it('calls onCancel when cancel button is clicked', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const cancelButton = screen.getByText('Cancelar');
+    fireEvent.click(cancelButton);
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+
+  it('calls onConfirm when delete button is clicked', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const deleteButton = screen.getByText('Eliminar');
+    fireEvent.click(deleteButton);
+
+    expect(mockOnConfirm).toHaveBeenCalledTimes(1);
+    expect(mockOnCancel).not.toHaveBeenCalled();
+  });
+
+  it('calls onCancel when overlay is clicked', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={mockOnConfirm}
+        onCancel={mockOnCancel}
+      />
+    );
+
+    const overlay = screen.getByText('Test Title').closest('.confirm-overlay');
+    fireEvent.click(overlay);
+
+    expect(mockOnCancel).toHaveBeenCalledTimes(1);
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/TaskItem.test.jsx
+++ b/frontend/src/__tests__/TaskItem.test.jsx
@@ -51,8 +51,51 @@ test('calls onDelete when delete button is clicked', () => {
   const mockDelete = vi.fn()
   render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={mockDelete} />)
 
-  fireEvent.click(screen.getByRole('button', { name: /eliminar/i }))
+  // Click delete button to open confirm dialog
+  const deleteButton = screen.getByRole('button', { name: /eliminar/i })
+  fireEvent.click(deleteButton)
+
+  // Verify confirm dialog appears with task title
+  expect(screen.getByText('Eliminar tarea')).toBeInTheDocument()
+  expect(screen.getByText(/¿Estás seguro de que quieres eliminar "Test task"\?/i)).toBeInTheDocument()
+
+  // Click confirm button in dialog
+  const confirmButton = screen.getAllByRole('button', { name: /eliminar/i })[1]
+  fireEvent.click(confirmButton)
+
+  // Verify onDelete was called with correct id
   expect(mockDelete).toHaveBeenCalledWith(1)
+})
+
+test('does not call onDelete when cancel button is clicked', () => {
+  const mockDelete = vi.fn()
+  render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={mockDelete} />)
+
+  // Click delete button to open confirm dialog
+  const deleteButton = screen.getByRole('button', { name: /eliminar/i })
+  fireEvent.click(deleteButton)
+
+  // Click cancel button in dialog
+  const cancelButton = screen.getByRole('button', { name: /cancelar/i })
+  fireEvent.click(cancelButton)
+
+  // Verify onDelete was not called
+  expect(mockDelete).not.toHaveBeenCalled()
+
+  // Verify dialog is closed
+  expect(screen.queryByText('Eliminar tarea')).not.toBeInTheDocument()
+})
+
+test('shows task title in confirm dialog message', () => {
+  const taskWithLongTitle = { ...mockTask, title: 'This is a very long task title' }
+  render(<TaskItem task={taskWithLongTitle} onToggle={() => {}} onDelete={() => {}} />)
+
+  // Click delete button to open confirm dialog
+  const deleteButton = screen.getByRole('button', { name: /eliminar/i })
+  fireEvent.click(deleteButton)
+
+  // Verify the dialog shows the task title
+  expect(screen.getByText(/¿Estás seguro de que quieres eliminar "This is a very long task title"\?/i)).toBeInTheDocument()
 })
 
 test('renders drag handle', () => {

--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const ConfirmDialog = ({ isOpen, title, message, onConfirm, onCancel }) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onCancel();
+    }
+  };
+
+  return (
+    <div className="confirm-overlay" onClick={handleOverlayClick}>
+      <div className="confirm-dialog">
+        <h2 className="confirm-title">{title}</h2>
+        <p className="confirm-message">{message}</p>
+        <div className="confirm-actions">
+          <button className="btn btn-cancel" onClick={onCancel}>
+            Cancelar
+          </button>
+          <button className="btn btn-delete" onClick={onConfirm}>
+            Eliminar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/frontend/src/components/TaskItem.jsx
+++ b/frontend/src/components/TaskItem.jsx
@@ -1,7 +1,10 @@
+import { useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import ConfirmDialog from './ConfirmDialog'
 
 function TaskItem({ task, onToggle, onDelete }) {
+  const [showConfirm, setShowConfirm] = useState(false)
   const {
     attributes,
     listeners,
@@ -34,11 +37,21 @@ function TaskItem({ task, onToggle, onDelete }) {
         {task.title}
       </span>
       <button
-        onClick={() => onDelete(task.id)}
+        onClick={() => setShowConfirm(true)}
         className="btn btn-delete"
       >
         Eliminar
       </button>
+      <ConfirmDialog
+        isOpen={showConfirm}
+        title="Eliminar tarea"
+        message={`¿Estás seguro de que quieres eliminar "${task.title}"?`}
+        onConfirm={() => {
+          onDelete(task.id)
+          setShowConfirm(false)
+        }}
+        onCancel={() => setShowConfirm(false)}
+      />
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -189,7 +189,7 @@ p {
 .confirm-actions {
   display: flex;
   gap: 0.5rem;
-  justify-content: flex-end;
+  justify-content: center;
 }
 
 .btn-cancel {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -148,3 +148,55 @@ p {
   text-decoration: line-through;
   color: #999;
 }
+
+/* Confirm Dialog */
+.confirm-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.confirm-dialog {
+  background-color: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  max-width: 400px;
+  width: 90%;
+}
+
+.confirm-title {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #2c3e50;
+  margin-bottom: 1rem;
+}
+
+.confirm-message {
+  font-size: 1rem;
+  color: #666;
+  margin-bottom: 1.5rem;
+  line-height: 1.5;
+}
+
+.confirm-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.btn-cancel {
+  background-color: #95a5a6;
+  color: white;
+}
+
+.btn-cancel:hover {
+  background-color: #7f8c8d;
+}


### PR DESCRIPTION
## Summary
Implementa un diálogo de confirmación modal antes de eliminar una tarea para prevenir eliminaciones accidentales. El nuevo componente `ConfirmDialog` es reutilizable y muestra el título de la tarea que se va a eliminar, ofreciendo opciones para cancelar o confirmar la acción.

Closes #16

## Implementation Plan
See implementation plan in issue #16 comments

## Changes
- Creado componente reutilizable `ConfirmDialog.jsx` con overlay modal y botones de acción
- Añadidos estilos CSS para el modal de confirmación (overlay, diálogo, botones)
- Integrado `ConfirmDialog` en `TaskItem.jsx` con gestión de estado local
- Modificado flujo de eliminación: ahora requiere confirmación explícita antes de eliminar
- Añadidos tests completos para `ConfirmDialog` (renderizado condicional, callbacks, cierre por overlay)
- Actualizados tests de `TaskItem` para verificar el nuevo flujo de confirmación
- Generada documentación técnica del feature en `app_docs/feature-16-delete-confirmation-dialog.md`
- Todos los tests (backend y frontend) pasan correctamente

## ADW
ADW ID: 387880c5
