### PR TITLE
feat: #26 - Quiero que las tareas completadas se muestren al final de la lista

### DIFF
--- a/app_docs/conditional_docs.md
+++ b/app_docs/conditional_docs.md
@@ -1,0 +1,13 @@
+# Conditional Documentation Index
+
+Este fichero contiene un índice de la documentación disponible en `app_docs/` junto con las condiciones en las que cada documento es relevante. Usa esta guía para saber qué documentación leer según el contexto de tu trabajo.
+
+## Documentos Disponibles
+
+- app_docs/feature-0996e753-separate-completed-tasks.md
+  - Condiciones:
+    - Cuando se trabaje con la visualización de tareas en el frontend
+    - Cuando se implemente funcionalidad de filtrado o separación de listas
+    - Cuando se modifique el componente TaskList o su comportamiento de renderizado
+    - Cuando se resuelvan problemas relacionados con drag-and-drop de tareas
+    - Cuando se trabaje con la estructura de secciones de tareas pendientes/completadas

--- a/app_docs/feature-0996e753-separate-completed-tasks.md
+++ b/app_docs/feature-0996e753-separate-completed-tasks.md
@@ -1,0 +1,72 @@
+# Separar Tareas Completadas en Lista Independiente
+
+**ADW ID:** 0996e753
+**Fecha:** 2026-03-04
+**Especificacion:** .issues/26/plan.md
+
+## Overview
+
+Se ha implementado una mejora en la visualización de tareas separando las tareas pendientes de las completadas en dos listas independientes con encabezados descriptivos. Esta separación mejora la organización visual y permite a los usuarios enfocarse en las tareas pendientes sin la distracción de las ya completadas.
+
+## Que se Construyo
+
+- Separación de tareas en dos secciones: pendientes y completadas
+- Encabezados descriptivos para cada sección ("Tareas pendientes" y "Tareas completadas")
+- Drag-and-drop habilitado solo para tareas pendientes
+- Estilo visual diferenciado para la sección de tareas completadas
+- Ocultamiento automático de la sección de completadas cuando está vacía
+- Suite de tests para verificar el comportamiento de las secciones
+
+## Implementacion Tecnica
+
+### Ficheros Modificados
+
+- `frontend/src/components/TaskList.jsx`: Refactorizado para filtrar y renderizar tareas en dos secciones separadas. El drag-and-drop ahora solo opera sobre tareas pendientes. Se añadió lógica para ocultar la sección de completadas cuando está vacía.
+- `frontend/src/index.css`: Añadidos estilos para las nuevas secciones, incluyendo clases `.task-section`, `.completed-section` y `.section-header` con estilos visuales diferenciados.
+- `frontend/src/__tests__/TaskList.test.jsx`: Añadidos 3 nuevos tests para verificar la renderización de encabezados, ocultamiento de sección vacía y orden correcto de las secciones.
+
+### Cambios Clave
+
+1. **Filtrado de tareas**: Se introducen dos arrays derivados `pendingTasks` y `completedTasks` que filtran el array original de tareas según su estado `completed`.
+
+2. **Drag-and-drop limitado**: El contexto de DnD (`DndContext` y `SortableContext`) ahora envuelve únicamente las tareas pendientes, manteniendo la funcionalidad de reordenamiento solo donde tiene sentido.
+
+3. **Reordenamiento inteligente**: Al reordenar tareas pendientes, se reconstruye el array completo manteniendo las tareas completadas al final para preservar el orden correcto en el backend.
+
+4. **Renderizado condicional**: La sección de tareas completadas solo se renderiza si `completedTasks.length > 0`, evitando secciones vacías innecesarias.
+
+5. **Estilos diferenciados**: La sección de completadas tiene un fondo sutil (`#fafafa`) y padding adicional para diferenciarla visualmente de las tareas pendientes.
+
+## Como Usar
+
+La funcionalidad es completamente transparente para el usuario y no requiere acciones especiales:
+
+1. **Ver tareas pendientes**: Aparecen en la primera sección bajo el encabezado "Tareas pendientes"
+2. **Ver tareas completadas**: Aparecen en la segunda sección bajo el encabezado "Tareas completadas" (solo si existen tareas completadas)
+3. **Completar una tarea**: Al marcar una tarea como completada, se moverá automáticamente a la sección de completadas
+4. **Reactivar una tarea**: Al desmarcar una tarea completada, volverá a la sección de pendientes
+5. **Reordenar tareas**: Solo las tareas pendientes pueden reordenarse mediante drag-and-drop
+
+## Configuracion
+
+No se requiere ninguna configuración adicional. Los cambios son puramente frontend y funcionan automáticamente al cargar la aplicación.
+
+## Testing
+
+Los tests cubren los siguientes escenarios:
+
+- **Renderización de encabezados**: Verifica que ambos encabezados aparecen cuando hay tareas de ambos tipos
+- **Ocultamiento de sección vacía**: Verifica que la sección de completadas no se muestra si no hay tareas completadas
+- **Orden correcto**: Verifica que las tareas pendientes aparecen antes que las completadas mediante la comprobación del orden de los encabezados
+
+Para ejecutar los tests:
+```bash
+cd frontend && npm test -- --run
+```
+
+## Notas
+
+- El comportamiento de drag-and-drop se mantiene solo para tareas pendientes para evitar confusión al reordenar tareas completadas
+- La transición visual al completar/descompletar una tarea es automática gracias al re-render de React
+- No se requieren cambios en el backend ya que la separación es puramente visual en el frontend
+- La implementación mantiene compatibilidad total con la API existente y no introduce cambios en el modelo de datos

--- a/frontend/src/__tests__/TaskList.test.jsx
+++ b/frontend/src/__tests__/TaskList.test.jsx
@@ -22,3 +22,33 @@ test('renders correct number of task items', () => {
   const checkboxes = screen.getAllByRole('checkbox')
   expect(checkboxes).toHaveLength(2)
 })
+
+test('shows section headers for pending and completed tasks', () => {
+  render(<TaskList tasks={mockTasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+  expect(screen.getByText('Tareas pendientes')).toBeInTheDocument()
+  expect(screen.getByText('Tareas completadas')).toBeInTheDocument()
+})
+
+test('hides completed section when no completed tasks', () => {
+  const pendingTasks = [
+    { id: 1, title: 'Task 1', completed: false },
+    { id: 2, title: 'Task 2', completed: false }
+  ]
+  render(<TaskList tasks={pendingTasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+  expect(screen.getByText('Tareas pendientes')).toBeInTheDocument()
+  expect(screen.queryByText('Tareas completadas')).not.toBeInTheDocument()
+})
+
+test('renders pending tasks before completed tasks', () => {
+  const mixedTasks = [
+    { id: 1, title: 'Completed 1', completed: true },
+    { id: 2, title: 'Pending 1', completed: false },
+    { id: 3, title: 'Pending 2', completed: false },
+    { id: 4, title: 'Completed 2', completed: true }
+  ]
+  render(<TaskList tasks={mixedTasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+
+  const headers = screen.getAllByRole('heading', { level: 2 })
+  expect(headers[0]).toHaveTextContent('Tareas pendientes')
+  expect(headers[1]).toHaveTextContent('Tareas completadas')
+})

--- a/frontend/src/components/TaskList.jsx
+++ b/frontend/src/components/TaskList.jsx
@@ -11,6 +11,9 @@ function TaskList({ tasks, onToggle, onDelete, onReorder }) {
     useSensor(KeyboardSensor)
   )
 
+  const pendingTasks = tasks.filter(task => !task.completed)
+  const completedTasks = tasks.filter(task => task.completed)
+
   if (tasks.length === 0) {
     return <p className="empty-message">No hay tareas. ¡Crea una nueva!</p>
   }
@@ -19,27 +22,50 @@ function TaskList({ tasks, onToggle, onDelete, onReorder }) {
     const { active, over } = event
     if (!over || active.id === over.id) return
 
-    const oldIndex = tasks.findIndex(t => t.id === active.id)
-    const newIndex = tasks.findIndex(t => t.id === over.id)
-    const newTasks = arrayMove(tasks, oldIndex, newIndex)
-    onReorder(newTasks.map(t => t.id))
+    const oldIndex = pendingTasks.findIndex(t => t.id === active.id)
+    const newIndex = pendingTasks.findIndex(t => t.id === over.id)
+    const newPendingTasks = arrayMove(pendingTasks, oldIndex, newIndex)
+
+    const allTasks = [...newPendingTasks, ...completedTasks]
+    onReorder(allTasks.map(t => t.id))
   }
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-      <SortableContext items={tasks.map(t => t.id)} strategy={verticalListSortingStrategy}>
-        <div className="task-list">
-          {tasks.map(task => (
-            <TaskItem
-              key={task.id}
-              task={task}
-              onToggle={onToggle}
-              onDelete={onDelete}
-            />
-          ))}
+    <div>
+      <div className="task-section">
+        <h2 className="section-header">Tareas pendientes</h2>
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={pendingTasks.map(t => t.id)} strategy={verticalListSortingStrategy}>
+            <div className="task-list">
+              {pendingTasks.map(task => (
+                <TaskItem
+                  key={task.id}
+                  task={task}
+                  onToggle={onToggle}
+                  onDelete={onDelete}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      </div>
+
+      {completedTasks.length > 0 && (
+        <div className="task-section completed-section">
+          <h2 className="section-header">Tareas completadas</h2>
+          <div className="task-list">
+            {completedTasks.map(task => (
+              <TaskItem
+                key={task.id}
+                task={task}
+                onToggle={onToggle}
+                onDelete={onDelete}
+              />
+            ))}
+          </div>
         </div>
-      </SortableContext>
-    </DndContext>
+      )}
+    </div>
   )
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -86,6 +86,26 @@ p {
   background-color: #c0392b;
 }
 
+/* Task Sections */
+.task-section {
+  margin-bottom: 1.5rem;
+}
+
+.task-section.completed-section {
+  background-color: #fafafa;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.section-header {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #555;
+  margin-bottom: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 2px solid #e0e0e0;
+}
+
 /* Task List */
 .task-list {
   display: flex;


### PR DESCRIPTION
## Summary
Implementa la separación de tareas completadas y pendientes en dos listas visuales distintas. La vista de tareas ahora muestra primero las tareas pendientes y, en una sección separada al final, las tareas completadas con estilo visual diferenciado (gris claro).

Closes #26

## Implementation Plan
See implementation plan in issue #26 comments

## Changes
- Modificado `TaskList.jsx` para separar tareas en dos listas (pendientes y completadas)
- Agregados estilos CSS para las secciones de tareas completadas
- Agregados tests para validar el orden y separación de las listas
- Documentada la funcionalidad de renderizado condicional
- Documentada la feature completa en `app_docs/feature-0996e753-separate-completed-tasks.md`

## ADW
ADW ID:
