### PR TITLE
feature: #31 - Quiero que las tareas completadas aparezcan agrupadas debajo de las pendientes

### DIFF
--- a/frontend/log/adw_dev.log
+++ b/frontend/log/adw_dev.log
@@ -1,0 +1,6 @@
+
+  VITE v6.4.1  ready in 738 ms
+
+  ➜  Local:   http://localhost:9598/
+  ➜  Network: http://192.168.68.109:9598/
+  ➜  Network: http://192.168.64.1:9598/

--- a/frontend/src/__tests__/TaskList.test.jsx
+++ b/frontend/src/__tests__/TaskList.test.jsx
@@ -22,3 +22,67 @@ test('renders correct number of task items', () => {
   const checkboxes = screen.getAllByRole('checkbox')
   expect(checkboxes).toHaveLength(2)
 })
+
+test('renders pending tasks before completed tasks', () => {
+  const mixedTasks = [
+    { id: 1, title: 'Completed Task', completed: true },
+    { id: 2, title: 'Pending Task', completed: false },
+    { id: 3, title: 'Another Pending', completed: false },
+    { id: 4, title: 'Another Completed', completed: true }
+  ]
+  const { container } = render(<TaskList tasks={mixedTasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+
+  const pendingSection = container.querySelector('.pending-tasks')
+  const completedSection = container.querySelector('.completed-tasks')
+
+  expect(pendingSection).toBeInTheDocument()
+  expect(completedSection).toBeInTheDocument()
+
+  // Verificar que la sección pendiente aparece antes que la completada
+  const taskList = container.querySelector('.task-list')
+  const sections = taskList.children
+  const pendingIndex = Array.from(sections).findIndex(el => el.classList.contains('pending-tasks'))
+  const separatorIndex = Array.from(sections).findIndex(el => el.classList.contains('tasks-separator'))
+  const completedIndex = Array.from(sections).findIndex(el => el.classList.contains('completed-tasks'))
+
+  expect(pendingIndex).toBeLessThan(separatorIndex)
+  expect(separatorIndex).toBeLessThan(completedIndex)
+})
+
+test('shows separator when there are completed tasks', () => {
+  render(<TaskList tasks={mockTasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+  expect(screen.getByText('Tareas completadas')).toBeInTheDocument()
+})
+
+test('does not show separator when there are no completed tasks', () => {
+  const pendingOnlyTasks = [
+    { id: 1, title: 'Task 1', completed: false },
+    { id: 2, title: 'Task 2', completed: false }
+  ]
+  render(<TaskList tasks={pendingOnlyTasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+  expect(screen.queryByText('Tareas completadas')).not.toBeInTheDocument()
+})
+
+test('does not show separator when there are only completed tasks', () => {
+  const completedOnlyTasks = [
+    { id: 1, title: 'Task 1', completed: true },
+    { id: 2, title: 'Task 2', completed: true }
+  ]
+  render(<TaskList tasks={completedOnlyTasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+  expect(screen.getByText('Tareas completadas')).toBeInTheDocument()
+})
+
+test('correctly groups pending and completed tasks', () => {
+  const mixedTasks = [
+    { id: 1, title: 'Pending 1', completed: false },
+    { id: 2, title: 'Completed 1', completed: true },
+    { id: 3, title: 'Pending 2', completed: false }
+  ]
+  const { container } = render(<TaskList tasks={mixedTasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+
+  const pendingSection = container.querySelector('.pending-tasks')
+  const completedSection = container.querySelector('.completed-tasks')
+
+  expect(pendingSection.children).toHaveLength(2) // 2 pending tasks
+  expect(completedSection.children).toHaveLength(1) // 1 completed task
+})

--- a/frontend/src/components/TaskList.jsx
+++ b/frontend/src/components/TaskList.jsx
@@ -11,6 +11,10 @@ function TaskList({ tasks, onToggle, onDelete, onReorder }) {
     useSensor(KeyboardSensor)
   )
 
+  // Separar tareas en pendientes y completadas
+  const pendingTasks = tasks.filter(t => !t.completed)
+  const completedTasks = tasks.filter(t => t.completed)
+
   if (tasks.length === 0) {
     return <p className="empty-message">No hay tareas. ¡Crea una nueva!</p>
   }
@@ -18,6 +22,16 @@ function TaskList({ tasks, onToggle, onDelete, onReorder }) {
   const handleDragEnd = (event) => {
     const { active, over } = event
     if (!over || active.id === over.id) return
+
+    // Encontrar la tarea que se está moviendo
+    const activeTask = tasks.find(t => t.id === active.id)
+    const overTask = tasks.find(t => t.id === over.id)
+
+    // Validar que ambas tareas existan
+    if (!activeTask || !overTask) return
+
+    // No permitir drag-and-drop entre grupos (pendientes y completadas)
+    if (activeTask.completed !== overTask.completed) return
 
     const oldIndex = tasks.findIndex(t => t.id === active.id)
     const newIndex = tasks.findIndex(t => t.id === over.id)
@@ -27,18 +41,46 @@ function TaskList({ tasks, onToggle, onDelete, onReorder }) {
 
   return (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-      <SortableContext items={tasks.map(t => t.id)} strategy={verticalListSortingStrategy}>
-        <div className="task-list">
-          {tasks.map(task => (
-            <TaskItem
-              key={task.id}
-              task={task}
-              onToggle={onToggle}
-              onDelete={onDelete}
-            />
-          ))}
-        </div>
-      </SortableContext>
+      <div className="task-list">
+        {/* Sección de tareas pendientes */}
+        {pendingTasks.length > 0 && (
+          <SortableContext items={pendingTasks.map(t => t.id)} strategy={verticalListSortingStrategy}>
+            <div className="pending-tasks">
+              {pendingTasks.map(task => (
+                <TaskItem
+                  key={task.id}
+                  task={task}
+                  onToggle={onToggle}
+                  onDelete={onDelete}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        )}
+
+        {/* Separador visual cuando hay tareas completadas */}
+        {completedTasks.length > 0 && (
+          <div className="tasks-separator">
+            <span>Tareas completadas</span>
+          </div>
+        )}
+
+        {/* Sección de tareas completadas */}
+        {completedTasks.length > 0 && (
+          <SortableContext items={completedTasks.map(t => t.id)} strategy={verticalListSortingStrategy}>
+            <div className="completed-tasks">
+              {completedTasks.map(task => (
+                <TaskItem
+                  key={task.id}
+                  task={task}
+                  onToggle={onToggle}
+                  onDelete={onDelete}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        )}
+      </div>
     </DndContext>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,6 +93,49 @@ p {
   gap: 0.5rem;
 }
 
+.pending-tasks,
+.completed-tasks {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.completed-tasks {
+  background-color: #fafafa;
+  padding: 0.75rem;
+  border-radius: 4px;
+}
+
+.tasks-separator {
+  margin: 1rem 0;
+  padding: 0.5rem 0;
+  text-align: center;
+  position: relative;
+}
+
+.tasks-separator::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background-color: #ddd;
+  z-index: 0;
+}
+
+.tasks-separator span {
+  position: relative;
+  z-index: 1;
+  background-color: white;
+  padding: 0 1rem;
+  color: #999;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .empty-message {
   text-align: center;
   color: #999;


### PR DESCRIPTION
## Summary
Esta implementación reorganiza las tareas en la lista para mostrar primero las pendientes y luego las completadas, agrupadas claramente en secciones separadas. Se mejora la experiencia de usuario al mantener el foco en las tareas activas mientras se preserva el historial de tareas completadas.

Closes #31

## Implementation Plan
See implementation plan in issue #31 comments

## Changes
- Modificado `TaskList.jsx` para separar tareas en dos grupos: pendientes y completadas
- Agregado estilo visual diferenciado para la sección de tareas completadas
- Implementados tests unitarios para verificar el orden y agrupación de tareas
- Añadidos estilos CSS para secciones de tareas con separador visual

## ADW
ADW ID: 0ab00682
