### PR TITLE
feat: #35 - QUiero añadir un dialog de confirmación cuando se vaya a borrar una tarea

### DIFF
--- a/frontend/src/__tests__/ConfirmDialog.test.jsx
+++ b/frontend/src/__tests__/ConfirmDialog.test.jsx
@@ -1,0 +1,96 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import ConfirmDialog from '../components/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('does not render when isOpen is false', () => {
+    const { container } = render(
+      <ConfirmDialog
+        isOpen={false}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the dialog when isOpen is true', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+  });
+
+  it('displays the correct title and message', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Confirmar eliminación"
+        message="¿Estás seguro de que quieres eliminar esta tarea?"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+      />
+    );
+    expect(screen.getByText('Confirmar eliminación')).toBeInTheDocument();
+    expect(screen.getByText('¿Estás seguro de que quieres eliminar esta tarea?')).toBeInTheDocument();
+  });
+
+  it('calls onConfirm when confirm button is clicked', () => {
+    const mockConfirm = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={mockConfirm}
+        onCancel={() => {}}
+      />
+    );
+    const confirmButton = screen.getByText('Confirmar');
+    fireEvent.click(confirmButton);
+    expect(mockConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const mockCancel = vi.fn();
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={() => {}}
+        onCancel={mockCancel}
+      />
+    );
+    const cancelButton = screen.getByText('Cancelar');
+    fireEvent.click(cancelButton);
+    expect(mockCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses custom button texts when provided', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onConfirm={() => {}}
+        onCancel={() => {}}
+        confirmText="Eliminar"
+        cancelText="No"
+      />
+    );
+    expect(screen.getByText('Eliminar')).toBeInTheDocument();
+    expect(screen.getByText('No')).toBeInTheDocument();
+    expect(screen.queryByText('Confirmar')).not.toBeInTheDocument();
+    expect(screen.queryByText('Cancelar')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/TaskItem.test.jsx
+++ b/frontend/src/__tests__/TaskItem.test.jsx
@@ -47,12 +47,64 @@ test('calls onToggle when checkbox is clicked', () => {
   expect(mockToggle).toHaveBeenCalledWith(1)
 })
 
-test('calls onDelete when delete button is clicked', () => {
+test('shows confirm dialog when delete button is clicked', () => {
   const mockDelete = vi.fn()
   render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={mockDelete} />)
 
-  fireEvent.click(screen.getByRole('button', { name: /eliminar/i }))
+  // Click the delete button
+  const deleteButton = screen.getAllByText('Eliminar')[0]
+  fireEvent.click(deleteButton)
+
+  // Check that the dialog is shown
+  expect(screen.getByRole('dialog')).toBeInTheDocument()
+  expect(screen.getByText('Confirmar eliminación')).toBeInTheDocument()
+  expect(screen.getByText('¿Estás seguro de que quieres eliminar "Test task"?')).toBeInTheDocument()
+})
+
+test('calls onDelete when confirm button in dialog is clicked', () => {
+  const mockDelete = vi.fn()
+  render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={mockDelete} />)
+
+  // Click the delete button to open dialog
+  const deleteButton = screen.getAllByText('Eliminar')[0]
+  fireEvent.click(deleteButton)
+
+  // Click the confirm button in the dialog
+  const confirmButton = screen.getAllByText('Eliminar')[1]
+  fireEvent.click(confirmButton)
+
+  // Check that onDelete was called
   expect(mockDelete).toHaveBeenCalledWith(1)
+})
+
+test('does not call onDelete when cancel button is clicked', () => {
+  const mockDelete = vi.fn()
+  render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={mockDelete} />)
+
+  // Click the delete button to open dialog
+  const deleteButton = screen.getAllByText('Eliminar')[0]
+  fireEvent.click(deleteButton)
+
+  // Click the cancel button
+  const cancelButton = screen.getByText('Cancelar')
+  fireEvent.click(cancelButton)
+
+  // Check that onDelete was NOT called
+  expect(mockDelete).not.toHaveBeenCalled()
+  // Check that the dialog is closed
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+})
+
+test('displays task title in confirmation dialog message', () => {
+  const taskWithLongTitle = { ...mockTask, title: 'My important task with a long title' }
+  render(<TaskItem task={taskWithLongTitle} onToggle={() => {}} onDelete={() => {}} />)
+
+  // Click the delete button
+  const deleteButton = screen.getAllByText('Eliminar')[0]
+  fireEvent.click(deleteButton)
+
+  // Check that the dialog shows the task title
+  expect(screen.getByText('¿Estás seguro de que quieres eliminar "My important task with a long title"?')).toBeInTheDocument()
 })
 
 test('renders drag handle', () => {

--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const ConfirmDialog = ({
+  isOpen,
+  title,
+  message,
+  onConfirm,
+  onCancel,
+  confirmText = 'Confirmar',
+  cancelText = 'Cancelar'
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="confirm-dialog-overlay" role="dialog">
+      <div className="confirm-dialog">
+        <h2 className="confirm-dialog-title">{title}</h2>
+        <p className="confirm-dialog-message">{message}</p>
+        <div className="confirm-dialog-actions">
+          <button className="btn-cancel" onClick={onCancel}>
+            {cancelText}
+          </button>
+          <button className="btn-delete" onClick={onConfirm}>
+            {confirmText}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDialog;

--- a/frontend/src/components/TaskItem.jsx
+++ b/frontend/src/components/TaskItem.jsx
@@ -1,7 +1,10 @@
+import { useState } from 'react'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import ConfirmDialog from './ConfirmDialog'
 
 function TaskItem({ task, onToggle, onDelete }) {
+  const [showConfirm, setShowConfirm] = useState(false)
   const {
     attributes,
     listeners,
@@ -34,11 +37,23 @@ function TaskItem({ task, onToggle, onDelete }) {
         {task.title}
       </span>
       <button
-        onClick={() => onDelete(task.id)}
+        onClick={() => setShowConfirm(true)}
         className="btn btn-delete"
       >
         Eliminar
       </button>
+      <ConfirmDialog
+        isOpen={showConfirm}
+        title="Confirmar eliminación"
+        message={`¿Estás seguro de que quieres eliminar "${task.title}"?`}
+        onConfirm={() => {
+          onDelete(task.id)
+          setShowConfirm(false)
+        }}
+        onCancel={() => setShowConfirm(false)}
+        confirmText="Eliminar"
+        cancelText="Cancelar"
+      />
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -148,3 +148,59 @@ p {
   text-decoration: line-through;
   color: #999;
 }
+
+/* Confirm Dialog */
+.confirm-dialog-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.confirm-dialog {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-width: 400px;
+  width: 90%;
+}
+
+.confirm-dialog-title {
+  margin-bottom: 1rem;
+  color: #2c3e50;
+  font-size: 1.25rem;
+}
+
+.confirm-dialog-message {
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+  color: #666;
+}
+
+.confirm-dialog-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.btn-cancel {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  background-color: #95a5a6;
+  color: white;
+}
+
+.btn-cancel:hover {
+  background-color: #7f8c8d;
+}


### PR DESCRIPTION
## Summary
Implementación de un dialog modal de confirmación para prevenir eliminaciones accidentales de tareas. Se creó un componente reutilizable `ConfirmDialog` que se integra en el flujo de eliminación existente, solicitando confirmación explícita antes de borrar definitivamente una tarea.

Closes #35

## Implementation Plan
See implementation plan in issue #35 comments

## Changes
- Creado componente `ConfirmDialog` reutilizable con overlay y modal
- Integrado dialog en flujo de eliminación de `TaskItem` con gestión de estado
- Añadidos estilos CSS coherentes con el diseño de la aplicación
- Implementada suite completa de tests para componente y flujo de confirmación
- Añadida accesibilidad básica con `role="dialog"`

## ADW
ADW ID: 9faf04b1
