### PR TITLE
feat: #34 - Quiero que las tareas completadas aparezcan agrupadas debajo de las pendientes

### DIFF
--- a/frontend/src/__tests__/TaskList.test.jsx
+++ b/frontend/src/__tests__/TaskList.test.jsx
@@ -22,3 +22,40 @@ test('renders correct number of task items', () => {
   const checkboxes = screen.getAllByRole('checkbox')
   expect(checkboxes).toHaveLength(2)
 })
+
+test('pending tasks appear before completed tasks', () => {
+  const tasks = [
+    { id: 1, title: 'Completed Task', completed: true },
+    { id: 2, title: 'Pending Task', completed: false }
+  ]
+  render(<TaskList tasks={tasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+
+  const taskTitles = screen.getAllByRole('checkbox').map(checkbox =>
+    checkbox.parentElement.querySelector('.task-title').textContent
+  )
+
+  // La primera tarea debe ser la pendiente
+  expect(taskTitles[0]).toBe('Pending Task')
+  // La segunda debe ser la completada
+  expect(taskTitles[1]).toBe('Completed Task')
+})
+
+test('shows "Completadas" header when there are completed tasks', () => {
+  const tasks = [
+    { id: 1, title: 'Pending Task', completed: false },
+    { id: 2, title: 'Completed Task', completed: true }
+  ]
+  render(<TaskList tasks={tasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+
+  expect(screen.getByText('Completadas')).toBeInTheDocument()
+})
+
+test('does not show "Completadas" header when there are no completed tasks', () => {
+  const tasks = [
+    { id: 1, title: 'Pending Task 1', completed: false },
+    { id: 2, title: 'Pending Task 2', completed: false }
+  ]
+  render(<TaskList tasks={tasks} onToggle={() => {}} onDelete={() => {}} onReorder={() => {}} />)
+
+  expect(screen.queryByText('Completadas')).not.toBeInTheDocument()
+})

--- a/frontend/src/components/TaskList.jsx
+++ b/frontend/src/components/TaskList.jsx
@@ -15,31 +15,59 @@ function TaskList({ tasks, onToggle, onDelete, onReorder }) {
     return <p className="empty-message">No hay tareas. ¡Crea una nueva!</p>
   }
 
+  // Separar tareas pendientes y completadas
+  const pendingTasks = tasks.filter(task => !task.completed)
+  const completedTasks = tasks.filter(task => task.completed)
+
   const handleDragEnd = (event) => {
     const { active, over } = event
     if (!over || active.id === over.id) return
 
-    const oldIndex = tasks.findIndex(t => t.id === active.id)
-    const newIndex = tasks.findIndex(t => t.id === over.id)
-    const newTasks = arrayMove(tasks, oldIndex, newIndex)
-    onReorder(newTasks.map(t => t.id))
+    // Solo permitir reordenar entre tareas pendientes
+    const oldIndex = pendingTasks.findIndex(t => t.id === active.id)
+    const newIndex = pendingTasks.findIndex(t => t.id === over.id)
+    const newPendingTasks = arrayMove(pendingTasks, oldIndex, newIndex)
+
+    // Combinar el nuevo orden de pendientes con las completadas
+    const allTaskIds = [...newPendingTasks.map(t => t.id), ...completedTasks.map(t => t.id)]
+    onReorder(allTaskIds)
   }
 
   return (
-    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-      <SortableContext items={tasks.map(t => t.id)} strategy={verticalListSortingStrategy}>
-        <div className="task-list">
-          {tasks.map(task => (
-            <TaskItem
-              key={task.id}
-              task={task}
-              onToggle={onToggle}
-              onDelete={onDelete}
-            />
-          ))}
+    <div>
+      {/* Seccion de tareas pendientes */}
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={pendingTasks.map(t => t.id)} strategy={verticalListSortingStrategy}>
+          <div className="task-list">
+            {pendingTasks.map(task => (
+              <TaskItem
+                key={task.id}
+                task={task}
+                onToggle={onToggle}
+                onDelete={onDelete}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+
+      {/* Seccion de tareas completadas */}
+      {completedTasks.length > 0 && (
+        <div className="completed-section">
+          <h3 className="section-header">Completadas</h3>
+          <div className="task-list">
+            {completedTasks.map(task => (
+              <TaskItem
+                key={task.id}
+                task={task}
+                onToggle={onToggle}
+                onDelete={onDelete}
+              />
+            ))}
+          </div>
         </div>
-      </SortableContext>
-    </DndContext>
+      )}
+    </div>
   )
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -148,3 +148,17 @@ p {
   text-decoration: line-through;
   color: #999;
 }
+
+/* Completed Section */
+.completed-section {
+  margin-top: 1.5rem;
+}
+
+.section-header {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #999;
+  margin-bottom: 0.75rem;
+  letter-spacing: 0.05em;
+}


### PR DESCRIPTION
## Summary
Implementa la funcionalidad para agrupar tareas completadas debajo de las tareas pendientes, mejorando la organización visual de la lista de tareas. Las tareas pendientes aparecen primero manteniendo la funcionalidad de drag-and-drop, mientras que las completadas se muestran en una sección separada con un encabezado visual.

Closes #34

## Implementation Plan
See implementation plan in issue #34 comments

## Changes
- Modificado `TaskList.jsx` para separar tareas en dos grupos (pendientes y completadas)
- Agregados estilos CSS para la sección de tareas completadas y su encabezado
- Implementados tests unitarios para verificar agrupación correcta y visualización condicional del encabezado
- Mantenida funcionalidad de drag-and-drop exclusivamente para tareas pendientes

## ADW
ADW ID: 3a9dde3c
