### PR TITLE
feature: #48 - Quiero añadir un dialog de confirmación a la hora de borrar tareas

### DIFF
--- a/app_docs/conditional_docs.md
+++ b/app_docs/conditional_docs.md
@@ -22,3 +22,10 @@ Este documento te ayuda a determinar que documentacion deberias leer en funcion 
     - Cuando trabajes con cualquier cosa bajo frontend/
     - Cuando necesites saber como arrancar o testear la aplicacion React
     - Cuando trabajes con componentes, servicios o estilos del frontend
+
+- app_docs/feature-fffcdc5b-confirm-delete-dialog.md
+  - Condiciones:
+    - Cuando trabajes con el componente ConfirmDialog o necesites implementar confirmaciones modales
+    - Cuando modifiques el flujo de eliminación de tareas
+    - Cuando necesites crear dialogs de confirmación reutilizables en React
+    - Cuando trabajes con modals, overlays o componentes de UI que requieran confirmación del usuario

--- a/app_docs/feature-fffcdc5b-confirm-delete-dialog.md
+++ b/app_docs/feature-fffcdc5b-confirm-delete-dialog.md
@@ -1,0 +1,113 @@
+# Dialog de Confirmación para Eliminar Tareas
+
+**ADW ID:** fffcdc5b
+**Fecha:** 2026-03-05
+**Especificación:** /Users/elafo/workspace/entaina/aurgi-curso-desarrolladores-sample-app/trees/issue-48/.issues/48/plan.md
+
+## Overview
+
+Se implementó un dialog modal de confirmación que aparece antes de eliminar una tarea, previniendo borrados accidentales. El usuario debe confirmar explícitamente la eliminación, viendo el título de la tarea que está a punto de eliminar.
+
+## Qué se Construyó
+
+- **Componente ConfirmDialog reutilizable**: Modal genérico para confirmaciones con overlay, título, mensaje y botones Cancelar/Confirmar
+- **Estado de gestión en App**: Lógica de estado para controlar qué tarea está pendiente de eliminación
+- **Integración con TaskItem**: Flujo completo de confirmación al hacer clic en el botón Eliminar
+- **Estilos CSS del modal**: Sistema de overlay y modal centrado con diseño consistente
+- **Suite de tests completa**: Tests unitarios del ConfirmDialog y tests de integración del flujo de eliminación
+
+## Implementación Técnica
+
+### Ficheros Modificados
+
+- `frontend/src/components/ConfirmDialog.jsx`: Nuevo componente modal reutilizable que recibe props para controlar visibilidad, contenido y callbacks
+- `frontend/src/__tests__/ConfirmDialog.test.jsx`: Tests unitarios del componente con cobertura de renderizado condicional, callbacks y clic en overlay
+- `frontend/src/App.jsx`: Añadido estado `taskToDelete` y funciones `handleRequestDelete`, `handleDeleteTask` modificada, y `handleCancelDelete`
+- `frontend/src/__tests__/App.test.jsx`: Tests de integración del flujo completo de confirmación de eliminación
+- `frontend/src/components/TaskItem.jsx`: Modificado `onDelete` para pasar el objeto task completo en lugar de solo el ID
+- `frontend/src/__tests__/TaskItem.test.jsx`: Actualizado test de onDelete para esperar el objeto task completo
+- `frontend/src/index.css`: Añadidos estilos para `.modal-overlay`, `.modal`, `.modal-title`, `.modal-message`, `.modal-actions`, y `.btn-cancel`
+- `frontend/package.json`: Añadida dependencia de testing `@testing-library/user-event`
+
+### Cambios Clave
+
+1. **Arquitectura de confirmación**: En lugar de eliminar directamente, `TaskItem` llama a `handleRequestDelete` que guarda la tarea en estado y muestra el dialog
+2. **Componente genérico**: `ConfirmDialog` es completamente reutilizable, aceptando título y mensaje personalizados vía props
+3. **Gestión de estado centralizada**: Todo el estado del dialog se maneja en `App.jsx`, manteniendo el flujo unidireccional de datos
+4. **Overlay interactivo**: El clic en el overlay (fuera del modal) cancela la operación sin eliminar
+5. **Prevención de propagación**: El modal usa `stopPropagation` para evitar que clics en el contenido cierren el dialog
+
+## Cómo Usar
+
+### Para Usuarios Finales
+
+1. Navega a la lista de tareas
+2. Haz clic en el botón rojo "Eliminar" de cualquier tarea
+3. Aparecerá un dialog mostrando: "¿Estás seguro de que quieres eliminar la tarea '[título de la tarea]'?"
+4. Opciones:
+   - Haz clic en "Cancelar" para cerrar el dialog sin eliminar
+   - Haz clic en "Confirmar" para eliminar la tarea definitivamente
+   - Haz clic fuera del modal (en el overlay oscuro) para cancelar
+
+### Para Desarrolladores
+
+Reutilizar el componente `ConfirmDialog` para otras confirmaciones:
+
+```jsx
+import ConfirmDialog from './components/ConfirmDialog'
+
+function MyComponent() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <ConfirmDialog
+      isOpen={isOpen}
+      title="Título del dialog"
+      message="Mensaje de confirmación"
+      onCancel={() => setIsOpen(false)}
+      onConfirm={() => {
+        // Ejecutar acción
+        setIsOpen(false)
+      }}
+    />
+  )
+}
+```
+
+## Configuración
+
+No requiere configuración adicional. El componente usa los estilos globales definidos en `frontend/src/index.css`.
+
+## Testing
+
+### Ejecutar Tests
+
+```bash
+cd frontend
+npm test -- --run
+```
+
+### Cobertura de Tests
+
+- **Tests unitarios de ConfirmDialog**:
+  - No renderiza cuando `isOpen` es false
+  - Renderiza título y mensaje cuando `isOpen` es true
+  - Llama a `onCancel` al hacer clic en Cancelar
+  - Llama a `onConfirm` al hacer clic en Confirmar
+  - Llama a `onCancel` al hacer clic en el overlay
+
+- **Tests de integración en App**:
+  - Muestra el dialog al hacer clic en Eliminar
+  - No elimina la tarea si se cancela el dialog
+  - Elimina la tarea si se confirma el dialog
+
+- **Tests actualizados de TaskItem**:
+  - Verifica que `onDelete` recibe el objeto task completo
+
+## Notas
+
+- **Reutilizable**: El componente `ConfirmDialog` está diseñado para ser genérico y puede usarse para cualquier tipo de confirmación en el futuro (ej: confirmar edición masiva, limpiar tareas completadas, etc.)
+- **Sin dependencias nuevas**: Implementado con React puro, solo se añadió `@testing-library/user-event` para testing
+- **Consistencia visual**: Los estilos siguen la paleta de colores existente en la aplicación
+- **Accesibilidad**: El overlay tiene z-index alto (1000) para garantizar que esté sobre todos los demás elementos
+- **UX defensiva**: Múltiples formas de cancelar (botón Cancelar, clic en overlay) para prevenir eliminaciones no deseadas

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.0",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.3.0",
         "jsdom": "^25.0.0",
         "vite": "^6.0.0",
@@ -1434,6 +1435,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@types/aria-query": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.3.0",
     "jsdom": "^25.0.0",
     "vite": "^6.0.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react'
 import TaskForm from './components/TaskForm'
 import TaskList from './components/TaskList'
+import ConfirmDialog from './components/ConfirmDialog'
 import { fetchTasks, createTask, updateTask, deleteTask, reorderTasks } from './services/api'
 
 function App() {
   const [tasks, setTasks] = useState([])
+  const [taskToDelete, setTaskToDelete] = useState(null)
 
   // Cargar tareas al montar el componente
   useEffect(() => {
@@ -27,9 +29,19 @@ function App() {
     await updateTask(id, { completed: !task.completed })
   }
 
-  const handleDeleteTask = async (id) => {
-    await deleteTask(id)
-    setTasks(tasks.filter(t => t.id !== id))
+  const handleRequestDelete = (task) => {
+    setTaskToDelete(task)
+  }
+
+  const handleDeleteTask = async () => {
+    if (!taskToDelete) return
+    await deleteTask(taskToDelete.id)
+    setTasks(tasks.filter(t => t.id !== taskToDelete.id))
+    setTaskToDelete(null)
+  }
+
+  const handleCancelDelete = () => {
+    setTaskToDelete(null)
   }
 
   const handleReorderTasks = async (taskIds) => {
@@ -45,8 +57,15 @@ function App() {
       <TaskList
         tasks={tasks}
         onToggle={handleToggleTask}
-        onDelete={handleDeleteTask}
+        onDelete={handleRequestDelete}
         onReorder={handleReorderTasks}
+      />
+      <ConfirmDialog
+        isOpen={taskToDelete !== null}
+        title="Confirmar eliminación"
+        message={`¿Estás seguro de que quieres eliminar la tarea "${taskToDelete?.title}"?`}
+        onCancel={handleCancelDelete}
+        onConfirm={handleDeleteTask}
       />
     </div>
   )

--- a/frontend/src/__tests__/App.test.jsx
+++ b/frontend/src/__tests__/App.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import App from '../App'
-import { fetchTasks, updateTask } from '../services/api'
+import { fetchTasks, updateTask, deleteTask } from '../services/api'
 
 // Mock del servicio API
 vi.mock('../services/api', () => ({
@@ -9,6 +10,38 @@ vi.mock('../services/api', () => ({
   updateTask: vi.fn().mockResolvedValue({}),
   deleteTask: vi.fn(),
   reorderTasks: vi.fn().mockResolvedValue([])
+}))
+
+// Mock de @dnd-kit
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }) => <div>{children}</div>,
+  closestCenter: vi.fn(),
+  PointerSensor: vi.fn(),
+  KeyboardSensor: vi.fn(),
+  useSensor: vi.fn(),
+  useSensors: vi.fn(() => []),
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }) => <div>{children}</div>,
+  verticalListSortingStrategy: vi.fn(),
+  arrayMove: vi.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: () => {},
+    transform: null,
+    transition: null,
+    isDragging: false,
+  }),
+}))
+
+vi.mock('@dnd-kit/utilities', () => ({
+  CSS: {
+    Transform: {
+      toString: () => undefined,
+    },
+  },
 }))
 
 test('renders Todo List heading', () => {
@@ -49,4 +82,67 @@ test('toggle calls updateTask with completed: false when task is completed', asy
   await waitFor(() => {
     expect(updateTask).toHaveBeenCalledWith(1, { completed: false })
   })
+})
+
+test('muestra el dialog al hacer clic en Eliminar', async () => {
+  const user = userEvent.setup()
+  fetchTasks.mockResolvedValue([{ id: 1, title: 'Task 1', completed: false }])
+
+  render(<App />)
+
+  await waitFor(() => {
+    expect(screen.getByText('Task 1')).toBeInTheDocument()
+  })
+
+  const deleteButton = screen.getByRole('button', { name: /eliminar/i })
+  await user.click(deleteButton)
+
+  expect(screen.getByText('Confirmar eliminación')).toBeInTheDocument()
+  expect(screen.getByText('¿Estás seguro de que quieres eliminar la tarea "Task 1"?')).toBeInTheDocument()
+})
+
+test('no elimina la tarea si se cancela el dialog', async () => {
+  const user = userEvent.setup()
+  fetchTasks.mockResolvedValue([{ id: 1, title: 'Task 1', completed: false }])
+  deleteTask.mockResolvedValue({})
+
+  render(<App />)
+
+  await waitFor(() => {
+    expect(screen.getByText('Task 1')).toBeInTheDocument()
+  })
+
+  const deleteButton = screen.getByRole('button', { name: /eliminar/i })
+  await user.click(deleteButton)
+
+  const cancelButton = screen.getByRole('button', { name: /cancelar/i })
+  await user.click(cancelButton)
+
+  expect(deleteTask).not.toHaveBeenCalled()
+  expect(screen.getByText('Task 1')).toBeInTheDocument()
+  expect(screen.queryByText('Confirmar eliminación')).not.toBeInTheDocument()
+})
+
+test('elimina la tarea si se confirma el dialog', async () => {
+  const user = userEvent.setup()
+  fetchTasks.mockResolvedValue([{ id: 1, title: 'Task 1', completed: false }])
+  deleteTask.mockResolvedValue({})
+
+  render(<App />)
+
+  await waitFor(() => {
+    expect(screen.getByText('Task 1')).toBeInTheDocument()
+  })
+
+  const deleteButton = screen.getByRole('button', { name: /eliminar/i })
+  await user.click(deleteButton)
+
+  const confirmButton = screen.getByRole('button', { name: /confirmar/i })
+  await user.click(confirmButton)
+
+  expect(deleteTask).toHaveBeenCalledWith(1)
+  await waitFor(() => {
+    expect(screen.queryByText('Task 1')).not.toBeInTheDocument()
+  })
+  expect(screen.queryByText('Confirmar eliminación')).not.toBeInTheDocument()
 })

--- a/frontend/src/__tests__/ConfirmDialog.test.jsx
+++ b/frontend/src/__tests__/ConfirmDialog.test.jsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConfirmDialog from '../components/ConfirmDialog';
+
+describe('ConfirmDialog', () => {
+  it('no renderiza nada cuando isOpen es false', () => {
+    const { container } = render(
+      <ConfirmDialog
+        isOpen={false}
+        title="Test Title"
+        message="Test Message"
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renderiza título y mensaje cuando isOpen es true', () => {
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Confirmar eliminación"
+        message="¿Estás seguro de que quieres eliminar esta tarea?"
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Confirmar eliminación')).toBeInTheDocument();
+    expect(screen.getByText('¿Estás seguro de que quieres eliminar esta tarea?')).toBeInTheDocument();
+    expect(screen.getByText('Cancelar')).toBeInTheDocument();
+    expect(screen.getByText('Confirmar')).toBeInTheDocument();
+  });
+
+  it('llama a onCancel cuando se hace clic en Cancelar', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onCancel={onCancel}
+        onConfirm={() => {}}
+      />
+    );
+
+    await user.click(screen.getByText('Cancelar'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('llama a onConfirm cuando se hace clic en Confirmar', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onCancel={() => {}}
+        onConfirm={onConfirm}
+      />
+    );
+
+    await user.click(screen.getByText('Confirmar'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('llama a onCancel cuando se hace clic en el overlay', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+
+    render(
+      <ConfirmDialog
+        isOpen={true}
+        title="Test Title"
+        message="Test Message"
+        onCancel={onCancel}
+        onConfirm={() => {}}
+      />
+    );
+
+    const overlay = screen.getByText('Test Title').parentElement.parentElement;
+    await user.click(overlay);
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/__tests__/TaskItem.test.jsx
+++ b/frontend/src/__tests__/TaskItem.test.jsx
@@ -52,7 +52,7 @@ test('calls onDelete when delete button is clicked', () => {
   render(<TaskItem task={mockTask} onToggle={() => {}} onDelete={mockDelete} />)
 
   fireEvent.click(screen.getByRole('button', { name: /eliminar/i }))
-  expect(mockDelete).toHaveBeenCalledWith(1)
+  expect(mockDelete).toHaveBeenCalledWith(mockTask)
 })
 
 test('renders drag handle', () => {

--- a/frontend/src/components/ConfirmDialog.jsx
+++ b/frontend/src/components/ConfirmDialog.jsx
@@ -1,0 +1,22 @@
+export default function ConfirmDialog({ isOpen, title, message, onCancel, onConfirm }) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="modal-overlay" onClick={onCancel}>
+      <div className="modal" onClick={(e) => e.stopPropagation()}>
+        <h2 className="modal-title">{title}</h2>
+        <p className="modal-message">{message}</p>
+        <div className="modal-actions">
+          <button className="btn-cancel" onClick={onCancel}>
+            Cancelar
+          </button>
+          <button className="btn-delete" onClick={onConfirm}>
+            Confirmar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/TaskItem.jsx
+++ b/frontend/src/components/TaskItem.jsx
@@ -34,7 +34,7 @@ function TaskItem({ task, onToggle, onDelete }) {
         {task.title}
       </span>
       <button
-        onClick={() => onDelete(task.id)}
+        onClick={() => onDelete(task)}
         className="btn btn-delete"
       >
         Eliminar

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -148,3 +148,60 @@ p {
   text-decoration: line-through;
   color: #999;
 }
+
+/* Modal */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background-color: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  max-width: 400px;
+  width: 90%;
+}
+
+.modal-title {
+  margin-bottom: 1rem;
+  color: #2c3e50;
+  font-size: 1.5rem;
+}
+
+.modal-message {
+  margin-bottom: 1.5rem;
+  color: #666;
+  line-height: 1.6;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: flex-end;
+}
+
+.btn-cancel {
+  padding: 0.5rem 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+  cursor: pointer;
+  background-color: white;
+  color: #333;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.btn-cancel:hover {
+  background-color: #f5f5f5;
+  border-color: #ccc;
+}


### PR DESCRIPTION
## Summary
Added a confirmation dialog when users attempt to delete tasks. This prevents accidental task deletions by requiring explicit user confirmation before the delete action is executed.

Closes #48

## Implementation Plan
See implementation plan in issue #48 comments

## Changes
- Created new `ConfirmDialog` component with accessible, styled confirmation UI
- Integrated confirmation dialog into task deletion flow in `App.jsx`
- Added comprehensive unit tests for ConfirmDialog component
- Updated App integration tests to verify confirmation dialog behavior
- Added feature documentation in `app_docs/feature-fffcdc5b-confirm-delete-dialog.md`
- Updated conditional documentation index with new feature reference

## ADW
ADW ID: fffcdc5b
